### PR TITLE
Initial "klog" API for app logs, supporting tags and rotating file logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ USEMODULE += gnrc_netif
 USEMODULE += gnrc_netapi
 USEMODULE += gnrc_netreg
 
-KUBOS_USEMODULES := gps radio ham
+KUBOS_USEMODULES := gps radio ham klog
 
 
 include $(KUBOS_MODULES)/Makefile.include

--- a/main.c
+++ b/main.c
@@ -1,7 +1,25 @@
-
+/*
+ * KubOS Core Flight Services
+ * Copyright (C) 2015 Kubos Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include <stdio.h>
 
 #include "shell.h"
+
+#define TAG "kubos"
+#include "klog.h"
 
 #ifdef MODULE_GPS
     extern int location_demo(int argc, char **argv);
@@ -32,14 +50,15 @@ const shell_command_t shell_commands[] = {
 
 int main(void)
 {
-    puts("Welcome to KubOS! Initializing...");
+    KLOG_INFO(TAG, "Welcome to KubOS! Initializing...");
 
 #ifdef MODULE_HAM
     ham_cmd_init();
 #endif
 
     /* start shell */
-    puts("All up, running the shell now");
+    KLOG_INFO(TAG, "All up, running the shell now");
+
     char line_buf[SHELL_DEFAULT_BUFSIZE];
     shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
 

--- a/modules/klog/Makefile
+++ b/modules/klog/Makefile
@@ -1,0 +1,5 @@
+MODULE = klog
+
+LINKFLAGS += -lm
+
+include $(RIOTBASE)/Makefile.base

--- a/modules/klog/klog.c
+++ b/modules/klog/klog.c
@@ -1,0 +1,189 @@
+/*
+ * KubOS Core Flight Services
+ * Copyright (C) 2015 Kubos Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <errno.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <timex.h>
+#include <xtimer.h>
+
+#include "klog.h"
+
+uint8_t klog_console_level = LOG_INFO;
+uint8_t klog_file_level = LOG_DEBUG;
+bool klog_file_logging = false;
+
+static FILE *_log_file = NULL;
+static char *_file_path = NULL;
+static uint8_t _file_path_len = 0;
+static uint8_t _current_part = 0;
+static uint32_t _current_part_size = 0;
+static uint32_t _part_size;
+static uint8_t _max_parts;
+
+static void _next_log_file(void)
+{
+    char buf[KLOG_PATH_LEN];
+    char *tail;
+    uint32_t pos = 0;
+    struct stat st;
+
+    klog_cleanup();
+    if (!_file_path) {
+        return;
+    }
+
+    _current_part = -1;
+    _current_part_size = 0;
+
+    strncpy(buf, _file_path, _file_path_len);
+    tail = buf + _file_path_len;
+
+    for (uint8_t i = 0; i < _max_parts; i++) {
+        sprintf(tail, ".%03d", i);
+
+        if (stat(buf, &st) == -1) {
+            if (errno == ENOENT) {
+                klog_console(LOG_DEBUG, "klog", "creating %s", buf);
+                _log_file = fopen(buf, "w+");
+                _current_part = i;
+                _current_part_size = 0;
+                break;
+            }
+            continue;
+        }
+
+        if (st.st_size < (off_t) _part_size) {
+            _log_file = fopen(buf, "r+");
+            _current_part = i;
+            pos = st.st_size - 1;
+            _current_part_size = st.st_size;
+            break;
+        }
+    }
+
+    if (!_log_file) {
+        // no empty or partial log file found, rotate
+        _current_part++;
+        if (_current_part > _max_parts) {
+            _current_part = 0;
+        }
+
+        sprintf(tail, ".%03d", _current_part);
+        remove(buf);
+
+        klog_console(LOG_DEBUG, "klog", "rotating to %s", buf);
+        _log_file = fopen(buf, "w+");
+    }
+
+    if (_log_file) {
+        klog_console(LOG_INFO, "klog", "logging to %s", buf);
+        klog_file_logging = true;
+        if (pos > 0) {
+            fseek(_log_file, 0, SEEK_END);
+        }
+    }
+}
+
+int klog_init_file(char *file_path, uint8_t file_path_len,
+                   uint32_t part_size, uint8_t max_parts)
+{
+    if (!file_path || file_path_len > KLOG_MAX_PATH) {
+        return -EINVAL;
+    }
+
+    _file_path = file_path;
+    _file_path_len = file_path_len;
+    _part_size = part_size;
+    _max_parts = max_parts;
+
+    _next_log_file();
+    return klog_file_logging ? 0 : -1;
+}
+
+static inline char *_level_str(unsigned level)
+{
+    switch (level) {
+        case LOG_ERROR: return "E";
+        case LOG_WARNING: return "W";
+        case LOG_INFO: return "I";
+        case LOG_DEBUG: return "D";
+        case LOG_NONE:
+        default:
+            return "N";
+    }
+}
+
+static int _klog(FILE *f, unsigned level, const char *logger,
+                 const char *format, va_list args)
+{
+    timex_t time;
+    int written = 0;
+    xtimer_now_timex(&time);
+
+    written += fprintf(f, "%010d.%03d %s:%s ", time.seconds,
+                       time.microseconds / 1000, logger, _level_str(level));
+    written += vfprintf(f, format, args);
+    written += fprintf(f, "\n");
+    return written;
+}
+
+void klog_console(unsigned level, const char *logger, const char *format, ...)
+{
+    va_list args;
+    va_start(args, format);
+
+    _klog(level == LOG_ERROR ? stderr : stdout, level, logger, format, args);
+
+    va_end(args);
+}
+
+void klog_file(unsigned level, const char *logger, const char *format, ...)
+{
+    va_list args;
+
+    va_start(args, format);
+    if (!_log_file) {
+        _next_log_file();
+        if (!_log_file) {
+            va_end(args);
+            return;
+        }
+    }
+
+    _current_part_size += _klog(_log_file, level, logger, format, args);
+
+    va_end(args);
+    fsync(fileno(_log_file));
+
+    if (_current_part_size >= _part_size) {
+        _next_log_file();
+    }
+}
+
+void klog_cleanup(void)
+{
+    if (_log_file) {
+        fsync(fileno(_log_file));
+        fclose(_log_file);
+        _log_file = NULL;
+    }
+}

--- a/modules/klog/klog.h
+++ b/modules/klog/klog.h
@@ -1,0 +1,74 @@
+/*
+ * KubOS Core Flight Services
+ * Copyright (C) 2015 Kubos Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef KLOG_H
+#define KLOG_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#define MODULE_LOG
+#include <log.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef KLOG_MAX_LINE
+#define KLOG_MAX_LINE 255
+#endif
+
+#define KLOG(level, logger, ...)  klog_write(level, logger, __VA_ARGS__)
+#define KLOG_ERR(logger, ...)     KLOG(LOG_ERROR, logger, __VA_ARGS__)
+#define KLOG_WARN(logger, ...)    KLOG(LOG_WARNING, logger, __VA_ARGS__)
+#define KLOG_INFO(logger, ...)    KLOG(LOG_INFO, logger, __VA_ARGS__)
+#define KLOG_DEBUG(logger, ...)   KLOG(LOG_DEBUG, logger, __VA_ARGS__)
+
+#define KLOG_SUFFIX_LEN 4
+#define KLOG_PATH_LEN   255
+#define KLOG_MAX_PATH   (KLOG_PATH_LEN - KLOG_SUFFIX_LEN - 1)
+
+#define KLOG_PART_SIZE_DEFAULT (1024 * 512)
+#define KLOG_MAX_PARTS_DEFAULT 4
+
+extern uint8_t klog_console_level;
+extern uint8_t klog_file_level;
+extern bool klog_file_logging;
+
+int klog_init_file(char *file_path, uint8_t file_path_len,
+                   uint32_t part_size, uint8_t max_parts);
+
+void klog_console(unsigned level, const char *logger, const char *format, ...);
+void klog_file(unsigned level, const char *logger, const char *format, ...);
+void klog_cleanup(void);
+
+#define klog_write(level, logger, ...) do { \
+    if (level <= klog_console_level) { \
+        klog_console(level, logger, __VA_ARGS__); \
+    } \
+    if (level <= klog_file_level && klog_file_logging) { \
+        klog_file(level, logger, __VA_ARGS__); \
+    } \
+} while (0)
+
+#define log_write(level, ...) klog_write(level, "RIOT", __VA_ARGS__)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/modules/klog/log_module.h
+++ b/modules/klog/log_module.h
@@ -1,0 +1,22 @@
+/*
+ * KubOS Core Flight Services
+ * Copyright (C) 2015 Kubos Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef LOG_MODULE_H
+#define LOG_MODULE_H
+
+#include "klog.h"
+
+#endif

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -25,6 +25,7 @@ KUBOS_MODULES := $(abspath $(KUBOS_MODULES))
 QUIET ?= 1
 
 # Modules to include:
+USEMODULE += auto_init
 USEMODULE += xtimer
 USEMODULE += embUnit
 USEMODULE += gnrc_pktbuf
@@ -32,7 +33,7 @@ USEMODULE += gnrc_netif
 USEMODULE += gnrc_netapi
 USEMODULE += gnrc_netreg
 
-KUBOS_USEMODULES := radio ham gps
+KUBOS_USEMODULES := radio ham gps klog
 
 CFLAGS += -g
 INCLUDES += -I$(RIOTBASE)/sys/include

--- a/test-suite/klog_test.c
+++ b/test-suite/klog_test.c
@@ -1,0 +1,156 @@
+/*
+ * KubOS Core Flight Services
+ * Copyright (C) 2015 Kubos Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <string.h>
+#include <stdio.h>
+#include <sys/stat.h>
+
+#include <embUnit.h>
+
+#include "klog.h"
+#include "tests.h"
+
+#define LOG_PATH "/tmp/_klog"
+
+static inline bool _fstat(char *path, int *size) {
+    struct stat st;
+    if (stat(path, &st) != 0) {
+        return false;
+    }
+
+    if (size) {
+        *size = (int) st.st_size;
+    }
+    return true;
+}
+
+#define remove_if_exists(p) if (_fstat(p, NULL)) remove(p)
+
+static void setUp(void)
+{
+    klog_console_level = LOG_NONE;
+}
+
+static void tearDown(void)
+{
+    klog_console_level = LOG_INFO;
+    klog_file_level = LOG_DEBUG;
+
+    klog_cleanup();
+    remove_if_exists(LOG_PATH ".000");
+    remove_if_exists(LOG_PATH ".001");
+    remove_if_exists(LOG_PATH ".002");
+    remove_if_exists(LOG_PATH ".003");
+    remove_if_exists(LOG_PATH ".004");
+}
+
+static void klog_file_log(void)
+{
+    klog_file_level = LOG_INFO;
+    int result = klog_init_file(LOG_PATH, strlen(LOG_PATH), 256, 1);
+    TEST_ASSERT_EQUAL_INT(result, 0);
+
+    KLOG_INFO("test", "123:%d", 456);
+    KLOG_WARN("logger", "hi");
+    KLOG_ERR("o", "error");
+    KLOG_DEBUG("b", "debug");
+    klog_cleanup();
+
+    FILE *log_file = fopen(LOG_PATH ".000", "r");
+    TEST_ASSERT_NOT_NULL(log_file);
+
+    char buffer[256];
+    char lines[4][64];
+    int i = 0;
+    fread(buffer, 1, 256, log_file);
+
+    for (char *token = strtok(buffer, "\n");
+         token;
+         token = strtok(NULL, "\n"), i++) {
+
+        strcpy(lines[i], token);
+    }
+
+    ASSERT_STRING_STARTS_WITH(&lines[0][14], " test:I 123:456");
+    ASSERT_STRING_STARTS_WITH(&lines[1][14], " logger:W hi");
+    ASSERT_STRING_STARTS_WITH(&lines[2][14], " o:E error");
+    TEST_ASSERT_EQUAL_INT(i, 4);
+}
+
+static void klog_rotate_parts(void)
+{
+    int result = klog_init_file(LOG_PATH, strlen(LOG_PATH), 32, 3);
+    int size;
+
+    TEST_ASSERT_EQUAL_INT(result, 0);
+
+    // This should be a line length of 21
+    KLOG_WARN("a", "b");
+    KLOG_WARN("a", "b");
+    klog_cleanup();
+
+    TEST_ASSERT(_fstat(LOG_PATH ".000", &size));
+    TEST_ASSERT_EQUAL_INT(size, 42);
+
+    KLOG_WARN("a", "b");
+    klog_cleanup();
+
+    TEST_ASSERT(_fstat(LOG_PATH ".000", &size));
+    TEST_ASSERT_EQUAL_INT(size, 42);
+    TEST_ASSERT(_fstat(LOG_PATH ".001", &size));
+    TEST_ASSERT_EQUAL_INT(size, 21);
+
+    KLOG_WARN("a", "b");
+    klog_cleanup();
+
+    TEST_ASSERT(_fstat(LOG_PATH ".000", &size));
+    TEST_ASSERT_EQUAL_INT(size, 42);
+    TEST_ASSERT(_fstat(LOG_PATH ".001", &size));
+    TEST_ASSERT_EQUAL_INT(size, 42);
+
+    // force rotation
+    KLOG_WARN("a", "b");
+    KLOG_WARN("a", "b");
+    klog_cleanup();
+
+    TEST_ASSERT(_fstat(LOG_PATH ".000", &size));
+    TEST_ASSERT_EQUAL_INT(size, 0);
+    TEST_ASSERT(_fstat(LOG_PATH ".001", &size));
+    TEST_ASSERT_EQUAL_INT(size, 42);
+    TEST_ASSERT(_fstat(LOG_PATH ".002", &size));
+    TEST_ASSERT_EQUAL_INT(size, 42);
+
+    KLOG_WARN("aa", "bb");
+    klog_cleanup();
+
+    TEST_ASSERT(_fstat(LOG_PATH ".000", &size));
+    TEST_ASSERT_EQUAL_INT(size, 23);
+    TEST_ASSERT(_fstat(LOG_PATH ".001", &size));
+    TEST_ASSERT_EQUAL_INT(size, 42);
+    TEST_ASSERT(_fstat(LOG_PATH ".002", &size));
+    TEST_ASSERT_EQUAL_INT(size, 42);
+}
+
+TestRef klog_suite(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(klog_file_log),
+        new_TestFixture(klog_rotate_parts),
+    };
+
+    EMB_UNIT_TESTCALLER(klog_tests, setUp, tearDown, fixtures);
+    return (TestRef) &klog_tests;
+}

--- a/test-suite/main.c
+++ b/test-suite/main.c
@@ -17,6 +17,7 @@ int main(void)
     TextUIRunner_runTest(ax25_suite());
     TextUIRunner_runTest(kiss_suite());
     TextUIRunner_runTest(nmea_suite());
+    TextUIRunner_runTest(klog_suite());
     TextUIRunner_end();
 
     lpm_set(LPM_POWERDOWN);

--- a/test-suite/tests.h
+++ b/test-suite/tests.h
@@ -26,6 +26,9 @@ extern "C" {
 
 #define ASSERT_EQUAL_INT TEST_ASSERT_EQUAL_INT
 #define ASSERT_EQUAL_STRING(s1, s2) TEST_ASSERT_EQUAL_STRING((const char *) s1, (const char *) s2)
+#define ASSERT_STRING_STARTS_WITH(s1, prefix) do { \
+    TEST_ASSERT_MESSAGE(strstr(s1, prefix) == s1, #s1 " !startswith " #prefix); \
+} while (0)
 #define ASSERT_FUZZY_EQUAL_FLOAT(f1, f2, precision) do { \
     float diff = powf(10, -precision); \
     TEST_ASSERT_MESSAGE(fabsf(f1 - f2) <= diff, #f1 " != " #f2); \
@@ -36,6 +39,7 @@ TestRef ax25_suite(void);
 TestRef aprs_suite(void);
 TestRef kiss_suite(void);
 TestRef nmea_suite(void);
+TestRef klog_suite(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
* Set console and file log level separately with klog_*_level
* Give discrete components their own logger: KLOG_INFO("mymodule", ...)
* Formats log messages with timestamp, logger, level, and message
* File logging is done on rotation, where each log file has a maximum
  size, with a max number of log files. Once the max files/size has been
  reached, the rotator will loop around and start over again
* Enable file logging with klog_init_file(..)
* Added tests for the new rotating logger

Fixes #17